### PR TITLE
Adicionado a opção de ordenar os banners 

### DIFF
--- a/app/controllers/spree/admin/banner_boxes_controller.rb
+++ b/app/controllers/spree/admin/banner_boxes_controller.rb
@@ -41,7 +41,7 @@ module Spree
         return @collection if @collection.present?
         params[:q] ||= {}
 
-        params[:q][:s] ||= 'category, position asc'
+        params[:q][:s] ||= 'position asc'
         @collection = super
 
         @q = @collection.ransack(params[:q])

--- a/app/controllers/spree/admin/banner_boxes_controller.rb
+++ b/app/controllers/spree/admin/banner_boxes_controller.rb
@@ -45,9 +45,7 @@ module Spree
         @collection = super
 
         @q = @collection.ransack(params[:q])
-        @collection = @q.result.
-            page(params[:page]).
-            per(params[:per_page] || Spree::Config[:admin_products_per_page])
+        @collection = @q.result
         @collection
       end
 

--- a/app/models/spree/banner_box.rb
+++ b/app/models/spree/banner_box.rb
@@ -1,5 +1,7 @@
 module Spree
   class BannerBox < ActiveRecord::Base
+    
+    acts_as_list
 
     has_attached_file :attachment,
                       styles: Spree::BannerConfig[:banner_styles].symbolize_keys!,

--- a/app/views/spree/admin/banner_boxes/index.html.erb
+++ b/app/views/spree/admin/banner_boxes/index.html.erb
@@ -46,9 +46,10 @@
 <div id="new_banner_box" data-hook></div>
 
 <% if @collection.any? %>
-    <table class="table" id="listing_banner_boxes">
+    <table class="table table sortable" id="listing_banner_boxes" data-sortable-link="<%= update_positions_admin_banner_boxes_path %>">
       <thead>
       <tr data-hook="rate_header">
+        <th></th>
         <th><%= Spree.t(:thumbnail) %></th>
         <th><%= Spree.t(:category) %></th>
         <th><%= Spree.t(:url) %></th>
@@ -58,6 +59,11 @@
       <tbody data-hook="admin_banner_boxes_index_rows">
       <% @collection.each do |banner_box|%>
           <tr id="<%= spree_dom_id banner_box %>" data-hook="banner_box_row">
+            <td class="move-handle">
+              <% if can? :edit, banner_box %>
+                <span class="icon icon-move handle"></span>
+              <% end %>
+            </td>
             <td><%= image_tag(banner_box.attachment(:mini)) %></td>
             <td><%= banner_box.category rescue '' %></td>
             <td><%= banner_box.url rescue '' %></td>
@@ -76,5 +82,3 @@
     <%= Spree.t(:no_results) %>
   </div>
 <% end %>
-
-<%= paginate @collection %>


### PR DESCRIPTION
Foi modificada a tabela de exibição dos banners para o usuário poder alterar a ordem de exibição deles e retirada a paginação do kaminari, para exibir todos eles na página de index dos banners